### PR TITLE
Add a prefix '@datetime' to be able to convert values to DateTime instances

### DIFF
--- a/lib/core/command.dart
+++ b/lib/core/command.dart
@@ -131,7 +131,7 @@ class Commands {
       },
     ),
     Command(
-      prefix: '\@',
+      prefix: '\@datetime',
       command: '',
       notprefix: '\$\[\]',
       callback: (DartDeclaration self, String testSubject, {String key, dynamic value}) {

--- a/lib/core/command.dart
+++ b/lib/core/command.dart
@@ -131,9 +131,18 @@ class Commands {
       },
     ),
     Command(
+      prefix: '\@',
+      command: '',
+      notprefix: '\$\[\]',
+      callback: (DartDeclaration self, String testSubject, {String key, dynamic value}) {
+        self.setName(key);
+        self.type = 'DateTime';
+        return self;
+      },
+    ),
+    Command(
       type: dynamic,
-      callback: (DartDeclaration self, dynamic testSubject,
-          {String key, dynamic value}) {
+      callback: (DartDeclaration self, dynamic testSubject, {String key, dynamic value}) {
         self.setName(key);
 
         if (value == null) {


### PR DESCRIPTION
A small improvement that will allow users to add a prefix to DateTime instances. 

This 
``` json 
{
  "id": 0,
  "name": "string",
  "email": "user@example.com",
  "created_at": "@2020-04-28T05:31:58.305Z",
  "updated_at": "@2020-04-28T05:31:58.305Z"
}
```

Will be converted to: 

```dart
import 'package:json_annotation/json_annotation.dart';

import 'image.dart';

part 'user.g.dart';

@JsonSerializable()
class User {
      User();

  int id;
  String name;
  String email;
  @JsonKey(name: 'created_at') DateTime createdAt;
  @JsonKey(name: 'updated_at') DateTime updatedAt;
 
  factory User.fromJson(Map<String,dynamic> json) => _$UserFromJson(json);
  Map<String, dynamic> toJson() => _$UserToJson(this);
}
```

And json_serializable will also pick this up and add fromJson en toJson for you!

```dart

// GENERATED CODE - DO NOT MODIFY BY HAND

part of 'user.dart';

// **************************************************************************
// JsonSerializableGenerator
// **************************************************************************

User _$UserFromJson(Map<String, dynamic> json) {
  return User()
    ..id = json['id'] as int
    ..name = json['name'] as String
    ..email = json['email'] as String
    ..createdAt = json['created_at'] == null
        ? null
        : DateTime.parse(json['created_at'] as String)
    ..updatedAt = json['updated_at'] == null
        ? null
        : DateTime.parse(json['updated_at'] as String)
}

Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
      'id': instance.id,
      'name': instance.name,
      'email': instance.email,
      'created_at': instance.createdAt?.toIso8601String(),
      'updated_at': instance.updatedAt?.toIso8601String()
    };

```