### PR TITLE
Expand Enums (added integer values conversion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ on `pubspec.yaml`
 
 ```yaml
 dependencies:
-  json_to_model: ^1.3.13
-  build_runner: ^1.7.4
-  json_serializable: ^3.2.5
+  json_to_model: ^1.4.1
+  build_runner: ^1.9.0
+  json_serializable: ^3.3.0
   json_annotation: ^3.0.1
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Create/copy `.json` files into `./jsons/`(default) on root of your project, and 
   "content": "$content",
   "tags": "$[]tag",
   "user_type": "@enum:admin,app_user,normal",
+  "auth_state": "@enum:verified(2),authenticated(1),guest(0)",
   "user": "$../user/user",
   "published": true
 }
@@ -69,7 +70,6 @@ or
 
 ```dart
 import 'package:json_annotation/json_annotation.dart';
-
 import 'content.dart';
 import 'tag.dart';
 import '../user/user.dart';
@@ -84,26 +84,54 @@ class Examples {
   String title;
   Content content;
   List<Tag> tags;
-  String userType;
-  UserTypeEnum get userTypeEnum => _userTypeEnumFromString(userType);
+  ExamplesUserTypeEnum 
+    get examplesUserTypeEnum => _examplesUserTypeEnumValues.map[userType];
+    set examplesUserTypeEnum(ExamplesUserTypeEnum value) => userType = _examplesUserTypeEnumValues.reverse[value];
+  @JsonKey(name: 'user_type') String userType;
+  ExamplesAuthStateEnum 
+    get examplesAuthStateEnum => _examplesAuthStateEnumValues.map[authState];
+    set examplesAuthStateEnum(ExamplesAuthStateEnum value) => authState = _examplesAuthStateEnumValues.reverse[value];
+  @JsonKey(name: 'auth_state') int authState;
   User user;
   bool published;
 
   factory Examples.fromJson(Map<String,dynamic> json) => _$ExamplesFromJson(json);
   Map<String, dynamic> toJson() => _$ExamplesToJson(this);
-  
-  UserTypeEnum _UserTypeEnumFromString(String input){
-    return UserTypeEnum.values.firstWhere(
-        (e) {
-          final element = e.toString().toLowerCase().substring(e.toString().indexOf('.') + 1);
-          return element == input;
-        },
-        orElse: () => null,
-      );
-  }
 }
 
-enum UserTypeEnum { Admin, AppUser, Normal }
+enum ExamplesUserTypeEnum { Admin, AppUser, Normal }
+enum ExamplesAuthStateEnum { Verified, Authenticated, Guest }
+
+final _examplesUserTypeEnumValues = _ExamplesUserTypeEnumConverter({
+  'admin': ExamplesUserTypeEnum.Admin,
+  'app_user': ExamplesUserTypeEnum.AppUser,
+  'normal': ExamplesUserTypeEnum.Normal,
+});
+
+
+final _examplesAuthStateEnumValues = _ExamplesAuthStateEnumConverter({
+  2: ExamplesAuthStateEnum.Verified,
+  1: ExamplesAuthStateEnum.Authenticated,
+  0: ExamplesAuthStateEnum.Guest,
+});
+
+class _ExamplesUserTypeEnumConverter<String, O> {
+  Map<String, O> map;
+  Map<O, String> reverseMap;
+
+  _ExamplesUserTypeEnumConverter(this.map);
+
+  Map<O, String> get reverse => reverseMap ??= map.map((k, v) => MapEntry(v, k));
+}
+
+class _ExamplesAuthStateEnumConverter<int, O> {
+  Map<int, O> map;
+  Map<O, int> reverseMap;
+
+  _ExamplesAuthStateEnumConverter(this.map);
+
+  Map<O, int> get reverse => reverseMap ??= map.map((k, v) => MapEntry(v, k));
+}
 ```
 
 ## Contents
@@ -164,7 +192,8 @@ this package will read `.json` file, and generate `.dart` file, asign the `type 
 | use `json_annotation` `@JsonKey`                      | {`"@JsonKey(...)"`:`...`}                            | `{"@JsonKey(ignore: true) dynamic": "val"}`                            | `@JsonKey(ignore: true) dynamic val;`                                        | -                                                 |
 | import other library(input value can be array)        | {`"@import"`:`...`}                                  | `{"@import":"package:otherlibrary/otherlibrary.dart"}`                 | -                                                                            | `import 'package:otherlibrary/otherlibrary.dart'` |
 | Datetime type                                         | {`...`:`"@datetime"`}                                | `{"createdAt": "@datetime:2020-02-15T15:47:51.742Z"}`                  | `DateTime createdAt;`                                                        | -                                                 |
-| Enum type                                             | {`...`:`"@enum:(folowed by enum separated by ',')"`} | `{"@import":"@enum:admin,app_user,normal"}`                            | `enum UserTypeEnum { Admin, AppUser, Normal }`(include variable declaration) | -                                                 |
+| Enum type                                             | {`...`:`"@enum:(folowed by enum separated by ',')"`} | `{"@import":"@enum:admin,app_user,normal"}`                            | `enum UserTypeEnum { Admin, AppUser, Normal }`(include variable declaration) | -             
+| Enum type with values                                 | {`...`:`"@enum:(folowed by enum separated by ',')"`} | `{"@import":"@enum:admin(0),app_user(1),normal(2)"}`                            | `enum UserTypeEnum { Admin, AppUser, Normal }`(include variable declaration) | -                                        |
 | write code independentally(experimental)              | {`"@_..."`:`...`}                                    | `{"@_ // any code here":",its like an escape to write your own code"}` | `// any code here,its like an escape to write your own code`                 | -                                                 |
 
 ## Examples
@@ -364,7 +393,6 @@ String defaultTemplate({
     className,
     declarations,
     enums,
-    enumConverters,
   }) =>  """
 import 'package:json_annotation/json_annotation.dart';
 
@@ -380,8 +408,7 @@ class $className {
 
   factory $className.fromJson(Map<String,dynamic> json) => _\$${className}FromJson(json);
   Map<String, dynamic> toJson() => _\$${className}ToJson(this);
-  
-  $enumConverters
+
 }
 
 $enums

--- a/lib/core/command.dart
+++ b/lib/core/command.dart
@@ -149,7 +149,6 @@ class Commands {
       callback: (DartDeclaration self, String testSubject, {String key, dynamic value}) {
         self.setEnumValues((value as String).substring('@enum:'.length).split(','));
         self.setName(key);
-        self.type = 'String';
         return self;
       },
     ),

--- a/lib/core/dart_declaration.dart
+++ b/lib/core/dart_declaration.dart
@@ -55,8 +55,8 @@ class DartDeclaration {
     return decorators?.join('\n');
   }
 
-  String getImportStrings() {
-    return imports.where((element) => element != null && element.isNotEmpty).map((e) => "import '$e.dart';").join('\n');
+  List<String> getImportStrings() {
+    return imports.where((element) => element != null && element.isNotEmpty).map((e) => "import '$e.dart';").toList();
   }
 
   static String getTypeFromJsonKey(String theString) {

--- a/lib/core/dart_declaration.dart
+++ b/lib/core/dart_declaration.dart
@@ -19,7 +19,7 @@ class DartDeclaration {
   List<String> enumValues = [];
   List<JsonModel> nestedClasses = [];
   bool get isEnum => enumValues.isNotEmpty;
-  
+
   DartDeclaration({
     this.jsonKey,
     this.type,
@@ -31,12 +31,11 @@ class DartDeclaration {
     jsonKey = JsonKeyMutate();
   }
 
-  @override
-  String toString() {
+  String toDeclaration(String className) {
     var declaration = '';
 
-    if(isEnum) {
-      declaration += '${getEnum().toImport()}\n';
+    if (isEnum) {
+      declaration += '${getEnum(className).toImport()}\n';
     }
 
     declaration += '${stringifyDecorator(getDecorator())}$type $name${stringifyAssignment(assignment)};'.trim();
@@ -57,10 +56,7 @@ class DartDeclaration {
   }
 
   String getImportStrings() {
-    return imports
-        .where((element) => element != null && element.isNotEmpty)
-        .map((e) => "import '$e.dart';")
-        .join('\n');
+    return imports.where((element) => element != null && element.isNotEmpty).map((e) => "import '$e.dart';").join('\n');
   }
 
   static String getTypeFromJsonKey(String theString) {
@@ -90,10 +86,11 @@ class DartDeclaration {
 
   void setEnumValues(List<String> values) {
     enumValues = values;
+    type = _detectType(values.first);
   }
 
-  Enum getEnum() {
-    return Enum(name, enumValues);
+  Enum getEnum(String className) {
+    return Enum(className, name, enumValues);
   }
 
   void addImport(import) {
@@ -110,11 +107,15 @@ class DartDeclaration {
 
   static DartDeclaration fromKeyValue(key, val) {
     var dartDeclaration = DartDeclaration();
-    dartDeclaration = fromCommand(Commands.valueCommands, dartDeclaration,
-        testSubject: val, key: key, value: val,);
+    dartDeclaration = fromCommand(
+      Commands.valueCommands,
+      dartDeclaration,
+      testSubject: val,
+      key: key,
+      value: val,
+    );
 
-    dartDeclaration = fromCommand(Commands.keyComands, dartDeclaration,
-        testSubject: key, key: key, value: val);
+    dartDeclaration = fromCommand(Commands.keyComands, dartDeclaration, testSubject: key, key: key, value: val);
     if (dartDeclaration.type == null || dartDeclaration.name == null) {
       exit(0);
     }
@@ -126,18 +127,13 @@ class DartDeclaration {
     var newSelf = self;
     for (var command in commandList) {
       if (testSubject is String) {
-        if ((command.prefix != null &&
-            testSubject.startsWith(command.prefix))) {
+        if ((command.prefix != null && testSubject.startsWith(command.prefix))) {
           if ((command.prefix != null &&
                   command.command != null &&
                   testSubject.startsWith(command.prefix + command.command)) ||
-              (command.command != null &&
-                  testSubject.startsWith(command.command))) {
-            if (command.notprefix != null &&
-                    !testSubject.startsWith(command.notprefix) ||
-                command.notprefix == null) {
-              newSelf =
-                  command.callback(self, testSubject, key: key, value: value);
+              (command.command != null && testSubject.startsWith(command.command))) {
+            if (command.notprefix != null && !testSubject.startsWith(command.notprefix) || command.notprefix == null) {
+              newSelf = command.callback(self, testSubject, key: key, value: value);
               break;
             }
           }
@@ -152,36 +148,76 @@ class DartDeclaration {
   }
 }
 
-class Enum{
+class Enum {
+  final String className;
   final String name;
   final List<String> values;
 
-  String get enumName => '${name.toTitleCase()}Enum';
+  var valueType = 'String';
 
-  Enum(this.name, this.values);
+  String get enumName => '$className${name.toTitleCase()}Enum';
+  String get converterName => '_${enumName.toTitleCase()}Converter';
+  String get enumValuesMapName => '_${enumName.toCamelCase()}Values';
+
+  Enum(this.className, this.name, this.values) {
+    valueType = _detectType(values.first);
+  }
+
+  String valueName(String input) {
+    if (input.contains('(')) {
+      return input.substring(0, input.indexOf('(')).toTitleCase();
+    } else {
+      return input.toTitleCase();
+    }
+  }
+
+  String valuesForTemplate() {
+    return values.map((e) {
+      final value = e.between('(', ')');
+      if (value != null) {
+        return '  $value: $enumName.${valueName(e)},';
+      } else {
+        return '  \'$e\': $enumName.${valueName(e)},';
+      }
+    }).join('\n');
+  }
 
   String toTemplateString() {
-    return 'enum $enumName { ${values.map((e) => e.toTitleCase()).toList().join(', ')} }';
+    return '''
+enum $enumName { ${values.map((e) => valueName(e)).toList().join(', ')} }
+
+
+final $enumValuesMapName = $converterName({
+${valuesForTemplate()}
+});
+
+
+class $converterName<$valueType, O> {
+  Map<$valueType, O> map;
+  Map<O, $valueType> reverseMap;
+
+  $converterName(this.map);
+
+  Map<O, $valueType> get reverse => reverseMap ??= map.map((k, v) => MapEntry(v, k));
+}
+''';
   }
 
   String toImport() {
     return '''
 $enumName 
-  get ${enumName.toCamelCase()} => _${enumName.toCamelCase()}FromString($name);
-  set ${enumName.toCamelCase()}($enumName value) => $name = _stringFrom$enumName(value);''';
+  get ${enumName.toCamelCase()} => $enumValuesMapName.map[$name];
+  set ${enumName.toCamelCase()}($enumName value) => $name = $enumValuesMapName.reverse[value];''';
   }
-
-  String toConverter() {
-   return ModelTemplates.indented('''
-$enumName _${enumName.toCamelCase()}FromString(String input) {
-  return $enumName.values.firstWhere(
-    (e) => _stringFrom$enumName(e) == input.toLowerCase(),
-    orElse: () => null,
-  );
 }
 
-String _stringFrom$enumName($enumName input) {
-  return input.toString().substring(input.toString().indexOf('.') + 1).toLowerCase();
-}''');
+String _detectType(String value) {
+  final firstValue = value.between('(', ')');
+  if (firstValue != null) {
+    final isInt = (int.tryParse(firstValue) ?? '') is int;
+    if (isInt) {
+      return 'int';
+    }
   }
+  return 'String';
 }

--- a/lib/core/json_model.dart
+++ b/lib/core/json_model.dart
@@ -15,11 +15,10 @@ class JsonModel {
   JsonModel(String fileName, List<DartDeclaration> dartDeclarations) {
     this.fileName = fileName;
     className = fileName.toTitleCase();
-    declaration = dartDeclarations.toDeclarationStrings();
+    declaration = dartDeclarations.toDeclarationStrings(className);
     imports = dartDeclarations.toImportStrings();
     imports_raw = dartDeclarations.getImportRaw();
-    enums = dartDeclarations.getEnums();
-    enumConverters = dartDeclarations.getEnumConverters();
+    enums = dartDeclarations.getEnums(className);
     nestedClasses = dartDeclarations.getNestedClasses();
   }
 

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -21,6 +21,16 @@ extension StringExtension on String {
     return '$leadingWord';
   }
 
+  String between(String start, String end) {
+    final startIndex = indexOf(start);
+    final endIndex = indexOf(end);
+    if (startIndex == -1) return null;
+    if (endIndex == -1) return null;
+    if (endIndex <= startIndex) return null;
+
+    return substring(startIndex + start.length, endIndex).trim();
+  }
+
   List<String> getWords() {
     var trimmed = trim();
     List<String> value;
@@ -48,8 +58,8 @@ extension StringExtension on String {
 }
 
 extension JsonKeyModels on List<DartDeclaration> {
-  String toDeclarationStrings() {
-    return map((e) => e.toString()).join('\n').trim();
+  String toDeclarationStrings(String className) {
+    return map((e) => e.toDeclaration(className)).join('\n').trim();
   }
 
   String toImportStrings() {
@@ -59,16 +69,9 @@ extension JsonKeyModels on List<DartDeclaration> {
         .join('\n');
   }
 
-  String getEnums() {
+  String getEnums(String className) {
     return where((element) => element.isEnum)
-        .map((e) => e.getEnum().toTemplateString())
-        .where((element) => element != null && element.isNotEmpty)
-        .join('\n');
-  }
-
-  String getEnumConverters() {
-    return where((element) => element.isEnum)
-        .map((e) => e.getEnum().toConverter())
+        .map((e) => e.getEnum(className).toTemplateString())
         .where((element) => element != null && element.isNotEmpty)
         .join('\n');
   }
@@ -88,7 +91,8 @@ extension JsonKeyModels on List<DartDeclaration> {
     where((element) => element.imports != null && element.imports.isNotEmpty).forEach((element) {
       imports_raw.addAll(element.imports);
       if (element.nestedClasses.isNotEmpty) {
-        imports_raw.addAll(element.nestedClasses.map((e) => e.imports_raw).reduce((value, element) => value..addAll(element)));
+        imports_raw
+            .addAll(element.nestedClasses.map((e) => e.imports_raw).reduce((value, element) => value..addAll(element)));
       }
     });
     imports_raw = imports_raw.where((element) => element != null && element.isNotEmpty).toList();

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -63,10 +63,18 @@ extension JsonKeyModels on List<DartDeclaration> {
   }
 
   String toImportStrings() {
-    return where((element) => element.imports != null && element.imports.isNotEmpty)
+    var imports = where((element) => element.imports != null && element.imports.isNotEmpty)
         .map((e) => e.getImportStrings())
         .where((element) => element != null && element.isNotEmpty)
-        .join('\n');
+        .fold<List<String>>(<String>[], (prev, current) => prev..addAll(current));
+
+    var nestedImports = where((element) => element.nestedClasses.isNotEmpty)
+        .map((e) => e.nestedClasses.map((jsonModel) => jsonModel.imports).toList())
+        .fold<List<String>>(<String>[], (prev, current) => prev..addAll(current));
+
+    imports.addAll(nestedImports);
+
+    return imports.join('\n');
   }
 
   String getEnums(String className) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: json_to_model
 description: Generate model class from Json file. partly inspired by json_model.
-version: 1.3.21
+version: 1.4.1
 homepage: https://github.com/fadhilx/json_to_model
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: json_to_model
 description: Generate model class from Json file. partly inspired by json_model.
-version: 1.3.20
+version: 1.3.21
 homepage: https://github.com/fadhilx/json_to_model
 
 environment:


### PR DESCRIPTION
This pull request allows for adding value mapping to enums. For example this allows you to convert `type` with int values `0, 1` into TypeEnum.ADMIN, TypeEnum.NORMAL.

Also the enum name conversion is now tied to the class name.

User.type will now be converted to UserTypeEnum (in previous version this would generate as TypeEnum and cause naming clashes.)

Also bumped the version.