### PR TITLE
fix enum value string method when value is not of type string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+- Use enum value type as return type for value getter
+
 ## 2.3.0
 
 - Preserve original case for fromJson and toJson

--- a/lib/core/dart_declaration.dart
+++ b/lib/core/dart_declaration.dart
@@ -351,7 +351,7 @@ class Enum {
 enum $enumName { ${values.map((e) => valueName(e)).toList().join(', ')} }
 
 extension ${enumName}Ex on $enumName{
-  String? get value => $enumValuesMapName.reverse[this];
+  String? get value => $enumValuesMapName.reverse[this].toString();
 }
 
 final $enumValuesMapName = $converterName({

--- a/lib/core/dart_declaration.dart
+++ b/lib/core/dart_declaration.dart
@@ -351,7 +351,7 @@ class Enum {
 enum $enumName { ${values.map((e) => valueName(e)).toList().join(', ')} }
 
 extension ${enumName}Ex on $enumName{
-  String? get value => $enumValuesMapName.reverse[this].toString();
+  $valueType? get value => $enumValuesMapName.reverse[this];
 }
 
 final $enumValuesMapName = $converterName({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: json_to_model
 description: Generate model class from Json file.
-version: 2.3.0
+version: 2.3.1
 homepage: https://github.com/fadhilx/json_to_model
 
 environment:


### PR DESCRIPTION
Fixed an error that caused the value getter of an enum to throw an error when the enum type was not a string.