### PR TITLE
fix: add jsonable property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.4
+
+- Added isJsonable property to dart time to fix .toJson/.fromJson generation on unsupported types
 ## 3.2.3
 
 - Loosen factory type requirements. If type is not found the factory will return a `null` value

--- a/lib/core/command.dart
+++ b/lib/core/command.dart
@@ -174,6 +174,10 @@ final List<Command> valueCommands = [
       final subject = testSubject as String;
       self.type = subject.substring(1);
       self.explicitTypeOverride = true;
+      self.isJsonable = self.type?.startsWith('Map') != true &&
+          self.type?.startsWith("List") != true &&
+          self.type != 'dynamic' &&
+          self.type != 'num';
       return self;
     },
   ),

--- a/lib/core/dart_declaration.dart
+++ b/lib/core/dart_declaration.dart
@@ -9,6 +9,7 @@ class DartDeclaration {
   List<String> imports = [];
   String? type;
   bool explicitTypeOverride = false;
+  bool isJsonable = true;
   dynamic jsonValue;
   String? originalName;
   String? name;
@@ -96,10 +97,7 @@ class DartDeclaration {
         conversion = '$jsonVar$isNullableString.toString()';
       } else if (type == 'double') {
         conversion = '($jsonVar as num).toDouble()';
-      } else if (explicitTypeOverride &&
-          type?.startsWith('Map') != true &&
-          type?.startsWith("List") != true &&
-          type != 'dynamic') {
+      } else if (explicitTypeOverride && isJsonable) {
         conversion = modelFromJson(jsonVar);
       } else {
         conversion = '$jsonVar as $type';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: json_to_model
 description: Generate model class from Json file.
-version: 3.2.3
+version: 3.2.4
 homepage: https://github.com/fadhilx/json_to_model
 
 environment:

--- a/test/extends_test.dart
+++ b/test/extends_test.dart
@@ -20,8 +20,6 @@ void main() {
 
     final output = modelFromJsonModel(jsonModel);
 
-    print(output);
-
     expect(output, contains("class ExtendsTest extends PageResponse<CategoryItem>  {"));
     expect(output, contains("import 'package:apn_http/apn_http.dart';"));
     expect(output, contains("  ExtendsTest({")); // double space indicates no const

--- a/test/jsonable_test.dart
+++ b/test/jsonable_test.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:json_to_model/core/json_model.dart';
+import 'package:json_to_model/core/model_template.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  test('Check if .fromJson is not used by a type that is not jsonable', () {
+    final content = json.decode(File('test/jsons/jsonable.json').readAsStringSync()) as Map<String, dynamic>;
+
+    final jsonModel = JsonModel.fromMap(
+      'jsonable',
+      content,
+      relativePath: './',
+      packageName: 'core',
+      indexPath: 'index.dart',
+    );
+
+    final output = modelFromJsonModel(jsonModel);
+
+    print(output);
+
+    expect(output, isNot(contains("num.fromJson")));
+    expect(output, isNot(contains("Map<String,dynamic.fromJson")));
+    expect(output, contains("Class.fromJson"));
+  });
+}

--- a/test/jsonable_test.dart
+++ b/test/jsonable_test.dart
@@ -23,5 +23,6 @@ void main() {
     expect(output, isNot(contains("num.fromJson")));
     expect(output, isNot(contains("Map<String,dynamic>.fromJson")));
     expect(output, contains("Class.fromJson"));
+    expect(output, contains("json['numValue'] as num"));
   });
 }

--- a/test/jsonable_test.dart
+++ b/test/jsonable_test.dart
@@ -20,10 +20,8 @@ void main() {
 
     final output = modelFromJsonModel(jsonModel);
 
-    print(output);
-
     expect(output, isNot(contains("num.fromJson")));
-    expect(output, isNot(contains("Map<String,dynamic.fromJson")));
+    expect(output, isNot(contains("Map<String,dynamic>.fromJson")));
     expect(output, contains("Class.fromJson"));
   });
 }

--- a/test/jsons/jsonable.json
+++ b/test/jsons/jsonable.json
@@ -1,6 +1,6 @@
 {
-    "num" : "#num", 
-    "map" : "#Map<String,dynamic>",
+    "numValue" : "#num", 
+    "mapValue" : "#Map<String,dynamic>",
     "class" : {
         "int" : 0
     }

--- a/test/jsons/jsonable.json
+++ b/test/jsons/jsonable.json
@@ -1,0 +1,7 @@
+{
+    "num" : "#num", 
+    "map" : "#Map<String,dynamic>",
+    "class" : {
+        "int" : 0
+    }
+}

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -46,7 +46,5 @@ void main() {
 
     expect(output, contains("value: json['value'] as dynamic"));
     expect(output, contains("'value': value"));
-
-    print(output);
   });
 }


### PR DESCRIPTION
Created a jsonable property to make sure that no ".fromJson" gets generated for types that do not support it 